### PR TITLE
fix: Add UI labels and correct audio output

### DIFF
--- a/Synthesiser/Source/Synth/AnalogVoice.cpp
+++ b/Synthesiser/Source/Synth/AnalogVoice.cpp
@@ -107,10 +107,10 @@ void AnalogVoice::renderNextBlock(juce::AudioBuffer<float>& outputBuffer, int st
     const float m_fmBA = getParamValue(apvts, ParamIDs::fmBA);
     const float m_amp = getParamValue(apvts, ParamIDs::amp);
 
-    auto* channelData = outputBuffer.getWritePointer(0);
-
+    // The main processing loop
     for (int i = startSample; i < startSample + numSamples; ++i)
     {
+        // Calculate one sample of the voice's output
         const float aEnv = ampEnv.process(getSampleRate());
         const float fEnv = filEnv.process(getSampleRate());
 
@@ -130,8 +130,15 @@ void AnalogVoice::renderNextBlock(juce::AudioBuffer<float>& outputBuffer, int st
         filt.set(modCut, res, fdrive);
         const float y = filt.processSample(mix);
 
-        channelData[i] += y * m_amp * aEnv;
+        const float outputSample = y * m_amp * aEnv;
 
+        // Write the calculated sample to all channels in the output buffer
+        for (int channel = 0; channel < outputBuffer.getNumChannels(); ++channel)
+        {
+            outputBuffer.getWritePointer(channel)[i] += outputSample;
+        }
+
+        // If the amp envelope is finished, the voice is no longer active
         if (!ampEnv.isActive())
         {
             clearCurrentNote();


### PR DESCRIPTION
This commit addresses feedback on the initial implementation.

Changes:
- **UI:** Added `juce::Label` components for all sliders and combo boxes in the `PluginEditor`. This makes it clear what each control modifies. The editor window size has been increased slightly to accommodate the new labels.
- **Bugfix:** Corrected the audio rendering logic in `AnalogVoice::renderNextBlock`. The previous implementation only wrote the output signal to the first channel (left). The code now correctly writes the mono output signal to all available channels in the output buffer, fixing the "no sound" issue in stereo setups.